### PR TITLE
Feature/dismodat 626 Drill location end

### DIFF
--- a/src/cascade_at/core/form/fields.py
+++ b/src/cascade_at/core/form/fields.py
@@ -30,6 +30,14 @@ class StrField(SimpleTypeField):
         super().__init__(str, *args, **kwargs)
 
 
+class NativeListField(SimpleTypeField):
+    """Because we already have a ListField for space separated
+    strings which become lists, this field type should be used
+    when the .json config returns a native python list."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(list, *args, **kwargs)
+
+
 class FormList(Form):
     """ This represents a homogeneous list of forms. For example, it might be
     used to contain a list of priors within a smoothing grid.

--- a/src/cascade_at/core/form/fields.py
+++ b/src/cascade_at/core/form/fields.py
@@ -3,7 +3,8 @@ mostly useful field types.
 """
 from re import split
 
-from cascade_at.core.form.abstract_form import Form, Field, SimpleTypeField, NO_VALUE
+from cascade_at.core.form.abstract_form import (
+    Form, Field, SimpleTypeField, NO_VALUE)
 from cascade_at.core.log import get_loggers
 
 LOG = get_loggers(__name__)

--- a/src/cascade_at/dismod/api/dismod_sqlite.py
+++ b/src/cascade_at/dismod/api/dismod_sqlite.py
@@ -176,9 +176,10 @@ class DismodSQLite:
         return df
 
     def _validate_data(self, table_definition, data):
-        """Validates that the dtypes in data match the expected types in the table_definition.
-        Pandas makes this difficult because DataFrames with no length have Object type,
-        and those with nulls become float type.
+        """Validates that the dtypes in data match the expected types in the
+        table_definition.
+        Pandas makes this difficult because DataFrames with no length have
+        Object type, and those with nulls become float type.
 
         Dismod-AT has its own set of rules about representation of null values.
 
@@ -197,29 +198,37 @@ class DismodSQLite:
 
         for column_name, column_definition in table_definition.c.items():
             if column_name in data:
-                actual_type = data[column_name].dtype
-                is_pandas_extension = isinstance(actual_type, ExtensionDtype)
                 expected_type = self._expected_type(column_definition)
                 is_nullable_numeric = (column_definition.nullable and
                                        expected_type in [int, float])
                 if is_nullable_numeric:
                     data[column_name] = data[column_name].fillna(value=np.nan)
-
+                actual_type = data[column_name].dtype
+                is_pandas_extension = isinstance(actual_type, ExtensionDtype)
                 if expected_type is int:
-                    self._check_int_type(actual_type, column_name, is_pandas_extension, table_definition)
+                    self._check_int_type(actual_type, column_name,
+                                         is_pandas_extension, table_definition)
                 elif expected_type is float:
-                    self._check_float_type(actual_type, column_name, table_definition)
+                    self._check_float_type(actual_type, column_name,
+                                           table_definition)
                 elif expected_type is str:
-                    self._check_str_type(actual_type, column_name, data, table_definition)
+                    self._check_str_type(actual_type, column_name, data,
+                                         table_definition)
                 else:
-                    raise RuntimeError(f"Unexpected type from column definitions: {expected_type}.")
-            elif not (column_definition.primary_key or column_definition.nullable):
-                raise DismodFileError(f"Missing column in data for table '{table_definition.name}': '{column_name}'")
+                    raise RuntimeError(f"Unexpected type from column "
+                                       f"definitions: {expected_type}.")
+            elif not (column_definition.primary_key or
+                      column_definition.nullable):
+                raise DismodFileError(f"Missing column in data for table "
+                                      f"'{table_definition.name}': "
+                                      f"'{column_name}'")
             columns_checked.add(column_name)
 
         extra_columns = set(data.columns).difference(table_definition.c.keys())
         if extra_columns:
-            raise DismodFileError(f"extra columns in data for table '{table_definition.name}': {extra_columns}")
+            raise DismodFileError(f"extra columns in data for table "
+                                  f"'{table_definition.name}': {extra_columns}"
+                                  )
 
     @staticmethod
     def _expected_type(column_definition):

--- a/src/cascade_at/dismod/api/table_metadata.py
+++ b/src/cascade_at/dismod/api/table_metadata.py
@@ -337,7 +337,7 @@ class Data(Base):
     integrand_id = Column(None, ForeignKey("integrand.integrand_id"), nullable=False)
     density_id = Column(None, ForeignKey("density.density_id"), nullable=False)
     node_id = Column(None, ForeignKey("node.node_id"), nullable=False)
-    weight_id = Column(None, ForeignKey("weight.weight_id"), nullable=False)
+    weight_id = Column(None, ForeignKey("weight.weight_id"), nullable=True)
     subgroup_id = Column(None, ForeignKey("subgroup.subgroup_id"), nullable=False)
     hold_out = Column(Integer(), nullable=False)
     """Zero or one for hold outs during fit command"""

--- a/src/cascade_at/executor/configure_inputs.py
+++ b/src/cascade_at/executor/configure_inputs.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from argparse import ArgumentParser
 
 from cascade_at.context.model_context import Context
@@ -9,11 +10,13 @@ from cascade_at.core.log import get_loggers, LEVELS
 LOG = get_loggers(__name__)
 
 
-def get_args():
+def get_args(args):
     """
     Parse the arguments for configuring inputs.
     :return:
     """
+    if args:
+        return args
     parser = ArgumentParser()
     parser.add_argument("-model-version-id", type=int, required=True,
                         help="model version ID (need this from database entry)")
@@ -22,10 +25,18 @@ def get_args():
     parser.add_argument("--configure", action='store_true',
                         help="whether or not to configure the application")
     parser.add_argument("--loglevel", type=str, required=False, default='info')
+    parser.add_argument("--json_file", type=str, required=False, default=None,
+                        help=("for testing, pass a json file directly by "
+                              "file path instead of referencing by model "
+                              "version ID"))
+    parser.add_argument("--test_dir", type=str, required=False, default=None,
+                        help=("if set, will save files to the directory "
+                              "specified. Invalidated if --configure is "
+                              "set"))
     return parser.parse_args()
 
 
-def main():
+def main(args=None):
     """
     Grabs the inputs for a specific model version ID, sets up the folder
     structure, and pickles the inputs object plus writes the settings json
@@ -34,7 +45,7 @@ def main():
     If you're doing a drill, then only get input data from locations
     that will be used for the drilling for parent-children.
     """
-    args = get_args()
+    args = get_args(args=args)
     logging.basicConfig(level=LEVELS[args.loglevel])
 
     LOG.info(f"Configuring inputs for model version ID {args.model_version_id}.")
@@ -43,12 +54,18 @@ def main():
     context = Context(
         model_version_id=args.model_version_id,
         make=args.make,
-        configure_application=args.configure
+        configure_application=args.configure,
+        root_directory=args.test_dir
     )
-    parameter_json = settings_json_from_model_version_id(
-        model_version_id=args.model_version_id,
-        conn_def=context.model_connection
-    )
+    if args.json_file:
+        LOG.info(f"Reading settings from file: {args.json_file}")
+        with open(args.json_file, 'r') as json_file:
+            parameter_json = json.load(json_file)
+    else:
+        parameter_json = settings_json_from_model_version_id(
+            model_version_id=args.model_version_id,
+            conn_def=context.model_connection
+        )
     settings = load_settings(settings_json=parameter_json)
 
     inputs = MeasurementInputsFromSettings(settings=settings)

--- a/src/cascade_at/executor/run.py
+++ b/src/cascade_at/executor/run.py
@@ -74,7 +74,7 @@ def main():
                 context.update_status(status='Failed')
                 raise RuntimeError(f"Command {c} failed with error"
                                    f"{process.stderr.decode()}")
-    
+
     context.update_status(status='Complete')
 
 

--- a/src/cascade_at/inputs/demographics.py
+++ b/src/cascade_at/inputs/demographics.py
@@ -1,15 +1,32 @@
+from typing import Optional
+
 from cascade_at.core.db import db_queries
+from cascade_at.inputs.locations import LocationDAG
+from cascade_at.inputs.utilites.gbd_ids import CascadeConstants
 
 
 class Demographics:
-    def __init__(self, gbd_round_id):
+    def __init__(self,
+                 gbd_round_id: int,
+                 location_set_version_id: Optional[int] = None):
         """
         Demographic groups needed for shared functions.
         """
-        demographics = db_queries.get_demographics(gbd_team='epi', gbd_round_id=gbd_round_id)
+        demographics = db_queries.get_demographics(
+            gbd_team='epi', gbd_round_id=gbd_round_id)
         self.age_group_id = demographics['age_group_id']
-        self.location_id = demographics['location_id']
         self.sex_id = demographics['sex_id'] + [3]
-        
-        cod_demographics = db_queries.get_demographics(gbd_team='cod', gbd_round_id=gbd_round_id)
+
+        cod_demographics = db_queries.get_demographics(
+            gbd_team='cod', gbd_round_id=gbd_round_id)
         self.year_id = cod_demographics['year_id']
+
+        if location_set_version_id:
+            location_dag = LocationDAG(
+                location_set_version_id=location_set_version_id,
+                gbd_round_id=gbd_round_id)
+            self.location_id = list(location_dag.dag.nodes)
+            self.mortality_rate_location_id = list(location_dag.dag.nodes)
+        else:
+            self.location_id = []
+            self.mortality_rate_location_id = []

--- a/src/cascade_at/inputs/locations.py
+++ b/src/cascade_at/inputs/locations.py
@@ -18,7 +18,9 @@ class LocationDAG:
 
         The root of this dag is the global location ID.
         """
-        LOG.info(f"Creating a location DAG for location_set_version_id {location_set_version_id}")
+        LOG.info(
+            f"Creating a location DAG for location_set_version_id "
+            f"{location_set_version_id}")
         self.location_set_version_id = location_set_version_id
 
         self.df = db_queries.get_location_metadata(
@@ -32,7 +34,8 @@ class LocationDAG:
             self.dag.add_node(int(row['location_id']), **row.to_dict())
         self.dag.add_edges_from([
             (int(row.parent_id), int(row.location_id))
-            for row in self.df.loc[self.df.location_id != CascadeConstants.GLOBAL_LOCATION_ID].itertuples()
+            for row in self.df.loc[
+                self.df.location_id != CascadeConstants.GLOBAL_LOCATION_ID].itertuples()
         ])
         self.dag.graph["root"] = CascadeConstants.GLOBAL_LOCATION_ID
 
@@ -51,11 +54,12 @@ class LocationDAG:
         :return:
         """
         return [location_id] + list(self.dag.successors(location_id))
-    
+
     def to_dataframe(self):
         """
-        Converts the location DAG to a data frame with location ID and parent ID
-        and name. Helpful for debugging, and putting into the dismod database.
+        Converts the location DAG to a data frame with location ID and parent
+        ID and name. Helpful for debugging, and putting into the dismod
+        database.
 
         Returns:
             pd.DataFrame
@@ -75,5 +79,3 @@ class LocationDAG:
             parent_id=parents,
             name=names
         ))
-
-

--- a/src/cascade_at/inputs/measurement_inputs.py
+++ b/src/cascade_at/inputs/measurement_inputs.py
@@ -132,13 +132,16 @@ class MeasurementInputs:
         self.decomp_step = ds.decomp_step_from_decomp_step_id(
             self.decomp_step_id
         )
-        self.demographics = Demographics(gbd_round_id=self.gbd_round_id)
         if location_set_version_id is None:
             self.location_set_version_id = get_location_set_version_id(
                 gbd_round_id=self.gbd_round_id
             )
         else:
             self.location_set_version_id = location_set_version_id
+
+        self.demographics = Demographics(
+            gbd_round_id=self.gbd_round_id,
+            location_set_version_id=self.location_set_version_id)
         self.location_dag = LocationDAG(
             location_set_version_id=self.location_set_version_id,
             gbd_round_id=self.gbd_round_id

--- a/src/cascade_at/inputs/measurement_inputs.py
+++ b/src/cascade_at/inputs/measurement_inputs.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from copy import copy
 from collections import defaultdict
+from typing import List, Optional
 
 from cascade_at.core.db import decomp_step as ds
 
@@ -15,31 +16,37 @@ from cascade_at.inputs.data import CrosswalkVersion
 from cascade_at.inputs.demographics import Demographics
 from cascade_at.inputs.locations import LocationDAG
 from cascade_at.inputs.population import Population
-from cascade_at.inputs.utilities.covariate_weighting import get_interpolated_covariate_values
+from cascade_at.inputs.utilities.covariate_weighting import (
+    get_interpolated_covariate_values)
 from cascade_at.inputs.utilities.gbd_ids import get_location_set_version_id
 from cascade_at.dismod.integrand_mappings import INTEGRAND_MAP
 from cascade_at.dismod.constants import IntegrandEnum
 from cascade_at.inputs.utilities.transformations import COVARIATE_TRANSFORMS
 from cascade_at.inputs.utilities.gbd_ids import SEX_ID_TO_NAME, SEX_NAME_TO_ID
 from cascade_at.inputs.utilities.reduce_data_volume import decimate_years
-from cascade_at.inputs.utilities.gbd_ids import CascadeConstants, StudyCovConstants
+from cascade_at.inputs.utilities.gbd_ids import (
+    CascadeConstants, StudyCovConstants)
 from cascade_at.model.utilities.grid_helpers import expand_grid
 
 LOG = get_loggers(__name__)
 
 
 class MeasurementInputs:
-    def __init__(self, model_version_id, gbd_round_id,
-                 decomp_step_id, csmr_process_version_id,
-                 csmr_cause_id, crosswalk_version_id,
-                 country_covariate_id,
-                 conn_def,
-                 location_set_version_id=None,
-                 drill=None):
+
+    def __init__(self, model_version_id: int,
+                 gbd_round_id: int, decomp_step_id: int,
+                 csmr_process_version_id: int,
+                 csmr_cause_id: int, crosswalk_version_id: int,
+                 country_covariate_id: int,
+                 conn_def: str,
+                 location_set_version_id: Optional[int]=None,
+                 drill_location_start: Optional[int]=None,
+                 drill_location_end: Optional[List[int]]=None):
         """
-        The class that constructs all of the measurement inputs. Pulls ASDR, CSMR, crosswalk versions,
-        and country covariates, and puts them into one data frame that then formats itself
-        for the dismod database. Performs covariate value interpolation if age and year ranges
+        The class that constructs all of the measurement inputs. Pulls ASDR,
+        CSMR, crosswalk versions, and country covariates, and puts them into
+        one data frame that then formats itself for the dismod database.
+        Performs covariate value interpolation if age and year ranges
         don't match up with GBD age and year ranges.
 
         Parameters:
@@ -52,48 +59,66 @@ class MeasurementInputs:
             country_covariate_id: (list of int) list of covariate IDs
             conn_def: (str) connection definition from .odbc file (e.g. 'epi')
             location_set_version_id: (int) can be None, if it's none, get the
-                best location_set_version_id for estimation hierarchy of this GBD round.
-            drill: (int) optional, which location ID to drill from as the parent
+            best location_set_version_id for estimation hierarchy of this
+                GBD round.
+            drill_location_start: (int) optional, which location ID to drill
+                from as the parent
+            drill_location_end: (intlist) optional, which immediate children
+                of the drill_location_start parent to include in the drill
 
         Attributes:
             self.decomp_step: (str) the decomp step in string form
-            self.demographics: (cascade_at.inputs.demographics.Demographics) a demographics object
-                that specifies the age group, sex, location, and year IDs to grab
-            self.integrand_map: (dict) dictionary mapping from GBD measure IDs to DisMod IDs
-            self.asdr: (cascade_at.inputs.asdr.ASDR) all-cause mortality input object
-            self.csmr: (cascade_at.inputs.csmr.CSMR) cause-specific mortality input object from cause
-                csmr_cause_id
-            self.data: (cascade_at.inputs.data.CrosswalkVersion) crosswalk version data from IHME database
-            self.covariate_data: (List[cascade_at.inputs.covariate_data.CovariateData]) list of covariate
-                data objects that contains the raw covariate data mapped to IDs
-            self.location_dag: (cascade_at.inputs.locations.LocationDAG) DAG of locations to be used
-            self.population: (cascade_at.inputs.population.Population) population object that is used
-                for covariate weighting
-            self.data_eta: (Dict[str, float]): dictionary of eta value to be applied to each measure
-            self.density: (Dict[str, str]): dictionary of density to be applied to each measure
-            self.nu: (Dict[str, float]): dictionary of nu value to be applied to each measure
-            self.dismod_data: (pd.DataFrame) resulting dismod data formatted to be used in the dismod database
-        
+            self.demographics: (cascade_at.inputs.demographics.Demographics) a
+                demographics object that specifies the age group, sex,
+                location, and year IDs to grab
+            self.integrand_map: (dict) dictionary mapping from GBD measure IDs
+                to DisMod IDs
+            self.asdr: (cascade_at.inputs.asdr.ASDR) all-cause mortality input
+                object
+            self.csmr: (cascade_at.inputs.csmr.CSMR) cause-specific mortality
+                input object from cause csmr_cause_id
+            self.data: (cascade_at.inputs.data.CrosswalkVersion) crosswalk
+                version data from IHME database
+            self.covariate_data: (List[
+                cascade_at.inputs.covariate_data.CovariateData]) list of
+                covariate data objects that contains the raw covariate data
+                mapped to IDs
+            self.location_dag: (cascade_at.inputs.locations.LocationDAG) DAG
+                of locations to be used
+            self.population: (cascade_at.inputs.population.Population)
+                population object that is used for covariate weighting
+            self.data_eta: (Dict[str, float]): dictionary of eta value to be
+                applied to each measure
+            self.density: (Dict[str, str]): dictionary of density to be
+                applied to each measure
+            self.nu: (Dict[str, float]): dictionary of nu value to be applied
+                to each measure
+            self.dismod_data: (pd.DataFrame) resulting dismod data formatted
+                to be used in the dismod database
+
         Usage:
         >>> from cascade_at.settings.base_case import BASE_CASE
         >>> from cascade_at.settings.settings import load_settings
 
         >>> settings = load_settings(BASE_CASE)
-        >>> covariate_ids = [i.country_covariate_id for i in settings.country_covariate]
+        >>> covariate_ids = [i.country_covariate_id for i in
+        >>>                  settings.country_covariate]
 
-        >>> i = MeasurementInputs(model_version_id=settings.model.model_version_id,
+        >>> i = MeasurementInputs(
+        >>>    model_version_id=settings.model.model_version_id,
         >>>            gbd_round_id=settings.gbd_round_id,
         >>>            decomp_step_id=settings.model.decomp_step_id,
         >>>            csmr_process_version_id=None,
         >>>            csmr_cause_id = settings.model.add_csmr_cause,
-        >>>            crosswalk_version_id=settings.model.crosswalk_version_id,
+        >>>    crosswalk_version_id=settings.model.crosswalk_version_id,
         >>>            country_covariate_id=covariate_ids,
         >>>            conn_def='epi',
-        >>>            location_set_version_id=settings.location_set_version_id)
+        >>>    location_set_version_id=settings.location_set_version_id)
         >>> i.get_raw_inputs()
         >>> i.configure_inputs_for_dismod()
         """
-        LOG.info(f"Initializing input object for model version ID {model_version_id}.")
+        LOG.info(f"Initializing input object for model version ID "
+                 f"{model_version_id}.")
         LOG.info(f"GBD Round ID {gbd_round_id}.")
         LOG.info(f"Pulling from connection {conn_def}.")
         self.model_version_id = model_version_id
@@ -119,13 +144,10 @@ class MeasurementInputs:
             gbd_round_id=self.gbd_round_id
         )
 
-        if drill:
-            LOG.info(
-                f"This is a DRILL model, so only going to pull data associated with "
-                f"drill location start {drill} and its descendants."
-            )
-            drill_descendants = list(self.location_dag.descendants(location_id=drill))
-            self.demographics.location_id = [drill] + drill_descendants
+        drill_locations = self.locations_by_drill(
+            drill_location_start, drill_location_end)
+        if drill_locations:
+            self.demographics.location_id = drill_locations
 
         self.exclude_outliers = True
         self.asdr = None
@@ -185,26 +207,31 @@ class MeasurementInputs:
             gbd_round_id=self.gbd_round_id
         ).get_population()
 
-    def configure_inputs_for_dismod(self, settings, mortality_year_reduction=5):
+    def configure_inputs_for_dismod(self, settings,
+                                    mortality_year_reduction=5):
         """
         Modifies the inputs for DisMod based on model-specific settings.
 
         :param settings: (cascade.settings.configuration.Configuration)
-        :param mortality_year_reduction: (int) number of years to decimate csmr and asdr
+        :param mortality_year_reduction: (int) number of years to
+            decimate csmr and asdr
         :return: self
         """
         self.data_eta = self.data_eta_from_settings(settings)
         self.density = self.density_from_settings(settings)
         self.nu = self.nu_from_settings(settings)
-        self.measures_to_exclude = self.measures_to_exclude_from_settings(settings)
+        self.measures_to_exclude = self.measures_to_exclude_from_settings(
+            settings)
 
         # If we are constraining omega, then we want to hold out the data
-        # from the DisMod fit for ASDR (but never CSMR -- always want to fit CSMR).
+        # from the DisMod fit for ASDR (but never CSMR -- always want to fit
+        # CSMR).
         data = self.data.configure_for_dismod(
             measures_to_exclude=self.measures_to_exclude,
             relabel_incidence=settings.model.relabel_incidence
         )
-        asdr = self.asdr.configure_for_dismod(hold_out=settings.model.constrain_omega)
+        asdr = self.asdr.configure_for_dismod(
+            hold_out=settings.model.constrain_omega)
         csmr = self.csmr.configure_for_dismod(hold_out=0)
 
         if settings.model.constrain_omega:
@@ -213,19 +240,24 @@ class MeasurementInputs:
             self.omega = None
 
         if not csmr.empty:
-            csmr = decimate_years(data=csmr, num_years=mortality_year_reduction)
+            csmr = decimate_years(
+                data=csmr, num_years=mortality_year_reduction)
         if not asdr.empty:
-            asdr = decimate_years(data=asdr, num_years=mortality_year_reduction)
+            asdr = decimate_years(
+                data=asdr, num_years=mortality_year_reduction)
 
         self.dismod_data = pd.concat([data, asdr, csmr], axis=0, sort=True)
         self.dismod_data.reset_index(drop=True, inplace=True)
 
-        self.dismod_data["density"] = self.dismod_data.measure.apply(self.density.__getitem__)
-        self.dismod_data["eta"] = self.dismod_data.measure.apply(self.data_eta.__getitem__)
-        self.dismod_data["nu"] = self.dismod_data.measure.apply(self.nu.__getitem__)
+        self.dismod_data["density"] = self.dismod_data.measure.apply(
+            self.density.__getitem__)
+        self.dismod_data["eta"] = self.dismod_data.measure.apply(
+            self.data_eta.__getitem__)
+        self.dismod_data["nu"] = self.dismod_data.measure.apply(
+            self.nu.__getitem__)
 
-        # This makes the specs not just for the country covariate but adds on the
-        # sex and one covariates.
+        # This makes the specs not just for the country covariate but adds on
+        # the sex and one covariates.
         self.covariate_specs = CovariateSpecs(
             country_covariates=settings.country_covariate,
             study_covariates=settings.study_covariate
@@ -236,7 +268,8 @@ class MeasurementInputs:
         ) for c in self.covariate_data}
 
         self.dismod_data = self.add_covariates_to_data(df=self.dismod_data)
-        self.dismod_data.loc[self.dismod_data.hold_out.isnull(), 'hold_out'] = 0.
+        self.dismod_data.loc[
+            self.dismod_data.hold_out.isnull(), 'hold_out'] = 0.
         self.dismod_data.drop(['age_group_id'], inplace=True, axis=1)
 
         return self
@@ -254,10 +287,12 @@ class MeasurementInputs:
             if c.study_country == 'country'
         }
 
-        df = self.interpolate_country_covariate_values(df=df, cov_dict=cov_dict_for_interpolation)
+        df = self.interpolate_country_covariate_values(
+            df=df, cov_dict=cov_dict_for_interpolation)
         df = self.transform_country_covariates(df=df)
 
-        df['s_sex'] = df.sex_id.map(SEX_ID_TO_NAME).map(StudyCovConstants.SEX_COV_VALUE_MAP)
+        df['s_sex'] = df.sex_id.map(
+            SEX_ID_TO_NAME).map(StudyCovConstants.SEX_COV_VALUE_MAP)
         df['s_one'] = StudyCovConstants.ONE_COV_VALUE
 
         return df
@@ -272,14 +307,15 @@ class MeasurementInputs:
                  f"and sex_id {sex_id}.")
         grid = expand_grid({
             'sex_id': [sex_id],
-            'location_id': self.location_dag.parent_children(parent_location_id),
+            'location_id': self.location_dag.parent_children(
+                parent_location_id),
             'year_id': self.demographics.year_id,
             'age_group_id': self.demographics.age_group_id
         })
         grid['time_lower'] = grid['year_id'].astype(int)
         grid['time_upper'] = grid['year_id'] + 1.
-        grid = BaseInput(gbd_round_id=self.gbd_round_id).convert_to_age_lower_upper(df=grid)
-
+        grid = BaseInput(
+            gbd_round_id=self.gbd_round_id).convert_to_age_lower_upper(df=grid)
         LOG.info("Adding covariates to avgint grid.")
         grid = self.add_covariates_to_data(df=grid)
         return grid
@@ -287,10 +323,11 @@ class MeasurementInputs:
     @staticmethod
     def calculate_omega(asdr, csmr):
         """
-        Calculates other cause mortality (omega) from ASDR (mtall -- all-cause mortality)
-        and CSMR (mtspecific -- cause-specific mortality). For most diseases, mtall is a
-        good approximation to omega, but we calculate omega = mtall - mtspecific in case it isn't.
-        For diseases without CSMR (self.csmr_cause_id = None), then omega = mtall.
+        Calculates other cause mortality (omega) from ASDR (mtall -- all-cause
+        mortality) and CSMR (mtspecific -- cause-specific mortality). For most
+        diseases, mtall is a good approximation to omega, but we calculate
+        omega = mtall - mtspecific in case it isn't. For diseases without CSMR
+        (self.csmr_cause_id = None), then omega = mtall.
         """
         join_columns = ['location_id', 'time_lower', 'time_upper',
                         'age_lower', 'age_upper', 'sex_id']
@@ -302,11 +339,12 @@ class MeasurementInputs:
             omega.rename(columns={'mtall': 'mean'}, inplace=True)
         else:
             mtspecific = csmr[join_columns + ['meas_value']].copy()
-            mtspecific.rename(columns={'meas_value': 'mtspecific'}, inplace=True)
+            mtspecific.rename(
+                columns={'meas_value': 'mtspecific'}, inplace=True)
             omega = mtall.merge(mtspecific, on=join_columns)
             omega['mean'] = omega['mtall'] - omega['mtspecific']
             omega.drop(columns=['mtall', 'mtspecific'], inplace=True)
-        
+
         negative_omega = omega['mean'] < 0
         if any(negative_omega):
             raise ValueError("There are negative values for omega. Must fix.")
@@ -338,24 +376,29 @@ class MeasurementInputs:
         """
         for c in self.covariate_specs.covariate_specs:
             if c.study_country == 'country':
-                LOG.info(f"Transforming the data for country covariate {c.covariate_id}.")
+                LOG.info(f"Transforming the data for country covariate "
+                         f"{c.covariate_id}.")
                 df[c.name] = df[c.name].apply(
                     lambda x: COVARIATE_TRANSFORMS[c.transformation_id](x)
                 )
         return df
 
-    def calculate_country_covariate_reference_values(self, parent_location_id, sex_id):
+    def calculate_country_covariate_reference_values(self,
+                                                     parent_location_id,
+                                                     sex_id):
         """
-        Gets the country covariate reference value for a covariate ID and a parent location ID.
-        Also gets the maximum difference between the reference value and covariate values observed.
+        Gets the country covariate reference value for a covariate ID and a
+        parent location ID. Also gets the maximum difference between the
+        reference value and covariate values observed.
 
-        Run this when you're going to make a DisMod AT database for a specific parent location
-        and sex ID.
+        Run this when you're going to make a DisMod AT database for a specific
+        parent location and sex ID.
 
         :param: (int)
         :param parent_location_id: (int)
         :param sex_id: (int)
-        :return: List[CovariateSpec] list of the covariate specs with the correct reference values and max diff.
+        :return: List[CovariateSpec] list of the covariate specs with the
+            correct reference values and max diff.
         """
         covariate_specs = copy(self.covariate_specs)
 
@@ -365,11 +408,12 @@ class MeasurementInputs:
         time_max = self.dismod_data.time_upper.max()
 
         children = list(self.location_dag.dag.successors(parent_location_id))
-        
+
         for c in covariate_specs.covariate_specs:
             if c.study_country == 'study':
                 if c.name == 's_sex':
-                    c.reference = StudyCovConstants.SEX_COV_VALUE_MAP[SEX_ID_TO_NAME[sex_id]]
+                    c.reference = StudyCovConstants.SEX_COV_VALUE_MAP[
+                        SEX_ID_TO_NAME[sex_id]]
                     c.max_difference = StudyCovConstants.MAX_DIFFERENCE_SEX_COV
                 elif c.name == 's_one':
                     c.reference = StudyCovConstants.ONE_COV_VALUE
@@ -380,18 +424,23 @@ class MeasurementInputs:
                 LOG.info(f"Calculating the reference and max difference for country covariate {c.covariate_id}.")
 
                 cov_df = self.country_covariate_data[c.covariate_id]
-                parent_df = cov_df.loc[cov_df.location_id == parent_location_id].copy()
+                parent_df = (
+                    cov_df.loc[cov_df.location_id == parent_location_id].copy()
+                )
                 child_df = cov_df.loc[cov_df.location_id.isin(children)].copy()
                 all_loc_df = pd.concat([child_df, parent_df], axis=0)
 
-                # if there is no data for the parent location at all (which there should be provided by Central Comp)
+                # if there is no data for the parent location at all (which
+                # there should be provided by Central Comp)
                 # then we are going to set the reference value to 0.
                 if cov_df.empty:
                     reference_value = 0
                     max_difference = np.nan
                 else:
                     pop_df = self.population.configure_for_dismod()
-                    pop_df = pop_df.loc[pop_df.location_id == parent_location_id].copy()
+                    pop_df = (
+                        pop_df.loc[pop_df.location_id == parent_location_id].copy()
+                    )
 
                     df_to_interp = pd.DataFrame({
                         'location_id': parent_location_id,
@@ -422,9 +471,10 @@ class MeasurementInputs:
         :return:
         """
         if not settings.model.is_field_unset("exclude_data_for_param"):
-            measures_to_exclude = [INTEGRAND_MAP[m].name
-                                   for m in settings.model.exclude_data_for_param
-                                   if m in INTEGRAND_MAP]
+            measures_to_exclude = [
+                INTEGRAND_MAP[m].name
+                for m in settings.model.exclude_data_for_param
+                if m in INTEGRAND_MAP]
         else:
             measures_to_exclude = list()
         if settings.policies.exclude_relative_risk:
@@ -436,7 +486,8 @@ class MeasurementInputs:
         """
         Gets the data eta from the settings Configuration.
         The default data eta is np.nan.
-        settings.eta.data: (Dict[str, float]): Default value for eta parameter on distributions
+        settings.eta.data: (Dict[str, float]): Default value for eta parameter
+            on distributions
             as a dictionary from measure name to float
 
         :param settings: (cascade.settings.configuration.Configuration)
@@ -481,9 +532,12 @@ class MeasurementInputs:
         """
         data_cv = defaultdict(lambda: default)
         if not settings.model.is_field_unset("minimum_meas_cv") and settings.model.minimum_meas_cv:
-            data_cv = defaultdict(lambda: float(settings.model.minimum_meas_cv))
+            data_cv = defaultdict(
+                lambda: float(settings.model.minimum_meas_cv))
         for set_data_cv in settings.data_cv_by_integrand:
-            data_cv[INTEGRAND_MAP[set_data_cv.integrand_measure_id].name] = float(set_data_cv.value)
+            data_cv[INTEGRAND_MAP[
+                set_data_cv.integrand_measure_id].name] = float(
+                    set_data_cv.value)
         return data_cv
 
     @staticmethod
@@ -491,8 +545,10 @@ class MeasurementInputs:
         """
         Gets nu from the settings Configuration.
         The default nu is np.nan.
-        settings.students_dof.data: (Dict[str, float]): The parameter for students-t distributions
-        settings.log_students_dof.data: (Dict[str, float]): The parameter for students-t distributions in log-space
+        settings.students_dof.data: (Dict[str, float]): The parameter for
+            students-t distributions
+        settings.log_students_dof.data: (Dict[str, float]): The parameter for
+            students-t distributions in log-space
 
         :param settings: (cascade.settings.configuration.Configuration)
         :return:
@@ -502,6 +558,36 @@ class MeasurementInputs:
         nu["log_students"] = settings.log_students_dof.data
         return nu
 
+    def locations_by_drill(self, drill_location_start, drill_location_end):
+        if not drill_location_start and drill_location_end:
+            raise ValueError(
+                "A location_drill_start must be specified in order "
+                "to perform a location drill.")
+        elif drill_location_start and not drill_location_end:
+            LOG.info(
+                f"This is a DRILL model, so only going to pull data "
+                f"associated with drill location start "
+                f"{drill_location_start} and its descendants."
+            )
+            drill_descendants = list(
+                self.location_dag.descendants(
+                    location_id=drill_location_start))
+            return [drill_location_start] + drill_descendants
+        elif drill_location_start and drill_location_end:
+            LOG.info(
+                f"This is a DRILL model, so only data for "
+                f"{drill_location_start} (the parent) and descendents "
+                f"of {drill_location_end} (the children) will be pulled."
+            )
+            drill_locations = [drill_location_start]
+            for child in drill_location_end:
+                drill_locations.append(child)
+                drill_locations = drill_locations + list(
+                    self.location_dag.descendants(location_id=child))
+            return drill_locations
+        else:
+            return None
+
     def reset_index(self, drop, inplace):
         pass
 
@@ -509,9 +595,10 @@ class MeasurementInputs:
 class MeasurementInputsFromSettings(MeasurementInputs):
     def __init__(self, settings):
         """
-        Wrapper for MeasurementInputs that takes a settings object rather than the
-        individual arguments. For convenience.
-        :param settings: (cascade.collector.settings_configuration.SettingsConfiguration)
+        Wrapper for MeasurementInputs that takes a settings object rather
+        than the individual arguments. For convenience.
+        :param settings: (
+            cascade.collector.settings_configuration.SettingsConfiguration)
 
         Example:
         >>> from cascade_at.settings.base_case import BASE_CASE
@@ -522,13 +609,16 @@ class MeasurementInputsFromSettings(MeasurementInputs):
         >>> i.get_raw_inputs()
         >>> i.configure_inputs_for_dismod()
         """
-        covariate_ids = [i.country_covariate_id for i in settings.country_covariate]
+        covariate_ids = [i.country_covariate_id for i in
+                         settings.country_covariate]
 
         if settings.model.drill:
-            drill = settings.model.drill_location_start
+            drill_location_start = settings.model.drill_location_start
+            drill_location_end = settings.model.drill_location_end
         else:
-            drill = None
-        
+            drill_location_start = None
+            drill_location_end = None
+
         super().__init__(
             model_version_id=settings.model.model_version_id,
             gbd_round_id=settings.gbd_round_id,
@@ -539,5 +629,6 @@ class MeasurementInputsFromSettings(MeasurementInputs):
             country_covariate_id=covariate_ids,
             conn_def='epi',
             location_set_version_id=settings.location_set_version_id,
-            drill=drill
+            drill_location_start=drill_location_start,
+            drill_location_end=drill_location_end
         )

--- a/src/cascade_at/inputs/measurement_inputs.py
+++ b/src/cascade_at/inputs/measurement_inputs.py
@@ -144,7 +144,7 @@ class MeasurementInputs:
             gbd_round_id=self.gbd_round_id
         )
 
-        drill_locations = self.locations_by_drill(
+        drill_locations, mr_locations = self.locations_by_drill(
             drill_location_start, drill_location_end)
         if drill_locations:
             self.demographics.location_id = drill_locations
@@ -569,10 +569,11 @@ class MeasurementInputs:
                 f"associated with drill location start "
                 f"{drill_location_start} and its descendants."
             )
-            drill_descendants = list(
-                self.location_dag.descendants(
-                    location_id=drill_location_start))
-            return [drill_location_start] + drill_descendants
+            drill_locations = ([drill_location_start]
+                               + list(self.location_dag.descendants(
+                                    location_id=drill_location_start)))
+            mr_locations = list(
+                self.location_dag.parent_children(drill_location_start))
         elif drill_location_start and drill_location_end:
             LOG.info(
                 f"This is a DRILL model, so only data for "
@@ -584,9 +585,11 @@ class MeasurementInputs:
                 drill_locations.append(child)
                 drill_locations = drill_locations + list(
                     self.location_dag.descendants(location_id=child))
-            return drill_locations
+            mr_locations = [drill_location_start] + drill_location_end
         else:
-            return None
+            drill_locations = None
+            mr_locations = None
+        return drill_locations, mr_locations
 
     def reset_index(self, drop, inplace):
         pass

--- a/src/cascade_at/jobmon/workflow.py
+++ b/src/cascade_at/jobmon/workflow.py
@@ -81,4 +81,3 @@ def jobmon_workflow_from_cascade_command(cc, context):
 
     wf.add_tasks(list(bash_tasks.values()))
     return wf
-

--- a/src/cascade_at/settings/base_case.py
+++ b/src/cascade_at/settings/base_case.py
@@ -29,7 +29,7 @@ BASE_CASE = {
             "iota"
         ],
         "bound_frac_fixed": 1.0e-8,
-        "drill_location_end": 72,
+        "drill_location_end": [72],
         "quasi_fixed": 0
     },
     "max_num_iter": {

--- a/src/cascade_at/settings/settings_configuration.py
+++ b/src/cascade_at/settings/settings_configuration.py
@@ -16,6 +16,7 @@ from cascade_at.core.form.fields import (
     IntField,
     FloatField,
     StrField,
+    NativeListField,
     StringListField,
     ListField,
     OptionField,
@@ -56,13 +57,11 @@ class SmoothingPrior(Form):
     def _full_form_validation(self, root):
         errors = []
 
-        if not (self.is_field_unset("age_lower") and not
-                self.is_field_unset("age_lower")):
+        if not self.is_field_unset("age_lower") and not self.is_field_unset("age_lower"):
             if self.age_lower > self.age_upper:
                 errors.append(
                     "age_lower must be less than or equal to age_upper")
-        if not (self.is_field_unset("time_lower") and not
-                self.is_field_unset("time_lower")):
+        if not self.is_field_unset("time_lower") and not self.is_field_unset("time_lower"):
             if self.time_lower > self.time_upper:
                 errors.append(
                     "time_lower must be less than or equal to time_upper")
@@ -150,8 +149,7 @@ class Smoothing(Form):
         errors = []
 
         if self.rate == "pini":
-            if not (self.is_field_unset("age_grid") and
-                    len(self.age_grid) != 1):
+            if not self.is_field_unset("age_grid") and len(self.age_grid) != 1:
                 errors.append("Pini must have exactly one age point")
         else:
             age_grid = self.age_grid or root.model.default_age_grid
@@ -250,7 +248,8 @@ class Model(Form):
     drill_location = IntField(display="Drill location", nullable=True)
     drill_location_start = IntField(
         display="Drill location start", nullable=True)
-    drill_location_end = IntField(display="Drill location end", nullable=True)
+    drill_location_end = NativeListField(
+        display="Drill location end", nullable=True)
     drill_sex = OptionField(
         [1, 2], constructor=int, nullable=True, display="Drill sex")
     birth_prev = OptionField(

--- a/tests/inputs/test_demographics.py
+++ b/tests/inputs/test_demographics.py
@@ -9,9 +9,21 @@ def D(ihme):
     return d
 
 
+@pytest.fixture(scope='module')
+def D_with_loc_set(ihme):
+    d = Demographics(gbd_round_id=6, location_set_version_id=544)
+    return d
+
+
 @pytest.mark.parametrize("attribute", [
     'age_group_id', 'location_id', 'year_id', 'sex_id'
 ])
 def test_demographics(D, attribute):
     assert type(getattr(D, attribute)) == list
-    assert getattr(D, attribute)
+    if not attribute == 'location_id':
+        assert getattr(D, attribute)
+
+
+def test_demographics_with_location_set(D_with_loc_set):
+    assert type(getattr(D_with_loc_set, 'location_id')) == list
+    assert getattr(D_with_loc_set, 'location_id')

--- a/tests/inputs/test_measurement_inputs.py
+++ b/tests/inputs/test_measurement_inputs.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from copy import deepcopy
 from random import choice, sample, randint
 
 from cascade_at.settings.base_case import BASE_CASE
@@ -75,12 +76,12 @@ def test_data_cv_from_settings_by_integrand():
 # are being correctly passed to the MeasurementInputs class.
 
 def test_location_drill_start_only():
-    settings = BASE_CASE.copy()
+    these_settings = deepcopy(BASE_CASE)
 
-    model_settings = settings["model"]
+    model_settings = these_settings["model"]
 
-    tree = LocationDAG(settings['location_set_version_id'],
-                       settings['gbd_round_id'])
+    tree = LocationDAG(these_settings['location_set_version_id'],
+                       these_settings['gbd_round_id'])
     region_ids = tree.parent_children(1)
     test_loc = choice(region_ids)
     num_descendants = len(tree.descendants(test_loc))
@@ -88,23 +89,24 @@ def test_location_drill_start_only():
 
     model_settings.pop("drill_location_end")
     model_settings['drill_location_start'] = test_loc
-    settings["model"] = model_settings
-    s = load_settings(settings)
+    these_settings["model"] = model_settings
+    s = load_settings(these_settings)
     mi = MeasurementInputsFromSettings(settings=s)
 
     # with drill_location_end unset, demographics.location_id should
     # be set to all descendants of the test loc, plus the test loc itself
     assert len(mi.demographics.location_id) == num_descendants + 1
     assert len(mi.demographics.mortality_rate_location_id) == num_mr_locs
+    these_settings
 
 
 def test_location_drill_start_end():
-    settings = BASE_CASE.copy()
+    these_settings = deepcopy(BASE_CASE)
 
-    model_settings = settings["model"]
+    model_settings = these_settings["model"]
 
-    tree = LocationDAG(settings['location_set_version_id'],
-                       settings['gbd_round_id'])
+    tree = LocationDAG(these_settings['location_set_version_id'],
+                       these_settings['gbd_round_id'])
     region_ids = tree.parent_children(1)
     parent_test_loc = choice(region_ids)
     test_children = list(tree.parent_children(parent_test_loc))
@@ -117,8 +119,8 @@ def test_location_drill_start_end():
 
     model_settings['drill_location_end'] = children_test_locs
     model_settings['drill_location_start'] = parent_test_loc
-    settings['model'] = model_settings
-    s = load_settings(settings)
+    these_settings['model'] = model_settings
+    s = load_settings(these_settings)
     mi = MeasurementInputsFromSettings(settings=s)
 
     # demographics.location_id shoul be set to all descendants of each
@@ -131,19 +133,19 @@ def test_location_drill_start_end():
 
 
 def test_no_drill():
-    settings = BASE_CASE.copy()
+    these_settings = deepcopy(BASE_CASE)
 
-    model_settings = settings["model"]
+    model_settings = these_settings["model"]
 
-    tree = LocationDAG(settings['location_set_version_id'],
-                       settings['gbd_round_id'])
+    tree = LocationDAG(these_settings['location_set_version_id'],
+                       these_settings['gbd_round_id'])
     num_descendants = len(tree.descendants(1))
 
     model_settings.pop('drill_location_end')
     model_settings.pop('drill_location_start')
 
-    settings['model'] = model_settings
-    s = load_settings(settings)
+    these_settings['model'] = model_settings
+    s = load_settings(these_settings)
     mi = MeasurementInputsFromSettings(settings=s)
 
     # since we haven't set either drill_location_start or

--- a/tests/inputs/test_measurement_inputs.py
+++ b/tests/inputs/test_measurement_inputs.py
@@ -75,7 +75,7 @@ def test_data_cv_from_settings_by_integrand():
 # This test at least ensures that drill location start and drill location end
 # are being correctly passed to the MeasurementInputs class.
 
-def test_location_drill_start_only():
+def test_location_drill_start_only(ihme):
     these_settings = deepcopy(BASE_CASE)
 
     model_settings = these_settings["model"]
@@ -100,7 +100,7 @@ def test_location_drill_start_only():
     these_settings
 
 
-def test_location_drill_start_end():
+def test_location_drill_start_end(ihme):
     these_settings = deepcopy(BASE_CASE)
 
     model_settings = these_settings["model"]
@@ -132,7 +132,7 @@ def test_location_drill_start_end():
         len(children_test_locs) + 1)
 
 
-def test_no_drill():
+def test_no_drill(ihme):
     these_settings = deepcopy(BASE_CASE)
 
     model_settings = these_settings["model"]

--- a/tests/inputs/test_measurement_inputs.py
+++ b/tests/inputs/test_measurement_inputs.py
@@ -3,7 +3,8 @@ import numpy as np
 
 from cascade_at.settings.base_case import BASE_CASE
 from cascade_at.settings.settings import load_settings
-from cascade_at.inputs.measurement_inputs import MeasurementInputs
+from cascade_at.inputs.measurement_inputs import (
+    MeasurementInputs, MeasurementInputsFromSettings)
 
 
 @pytest.mark.parametrize("column,values", [
@@ -47,9 +48,9 @@ def test_data_cv_from_settings_by_integrand():
     settings = BASE_CASE.copy()
     settings.update({
         "data_cv_by_integrand": [{
-                "integrand_measure_id": 5,
-                "value": 0.5
-            }]
+            "integrand_measure_id": 5,
+            "value": 0.5
+        }]
     })
     s = load_settings(settings)
     cv = MeasurementInputs.data_cv_from_settings(settings=s)
@@ -58,3 +59,14 @@ def test_data_cv_from_settings_by_integrand():
             assert v == 0.5
         else:
             assert v == 0.1
+
+
+def test_location_drill_start_only():
+    settings = BASE_CASE.copy()
+    model_settings = settings["model"]
+    model_settings.pop("drill_location_end")
+    model_settings['drill_location_start']
+    settings["model"] = model_settings
+    s = load_settings(settings)
+    mi = MeasurementInputsFromSettings(settings=s)
+    assert len(mi.demographics.location_id) == 33


### PR DESCRIPTION
Need thorough review from @mbannick.  Currently setup to stash two different lists of location_ids on the Demographics object depending on the value(s) of drill_location_start and drill_location_end.  Summing up:

If only drill_location_start is specified:
store all drill_location_start and all children (at all levels of the location hierarchy) of drill_location_start in demographics.location_id
store only drill_location_start and all its immediate children in demographics.mortality_rate_location_id

If both drill_location_start and drill_location_end are specified:
store drill_location_end + each location in drill_location_end + all descendants of each location specified in drill_location_end in Demographics.location_id
store only drill_location_end + each location in drill_location_end in Demographics.mortality_rate_location_id

If neither are specified:
store entire hierarchy in both Demographics.location_id and Demographics.mortality_rate_location_id

So far the only place Demographics.mortality_rate_location_id is getting used is in the inputs.CSMR module.  I expect to be told to use it elsewhere but I don't currently have the background knowledge to know exactly where.  Please advise.
<img width="716" alt="Screen Shot 2020-04-01 at 4 44 40 PM" src="https://user-images.githubusercontent.com/61817882/78197750-26bc7980-743b-11ea-8c57-12e7bc8e76a7.png">
